### PR TITLE
Session3: StatefulWidget

### DIFF
--- a/lib/green_screen.dart
+++ b/lib/green_screen.dart
@@ -13,11 +13,14 @@ class _GreenScreenState extends State<GreenScreen> {
   @override
   void initState() {
     super.initState();
-    unawaited(navigateToWeatherScreen());
+    unawaited(
+      WidgetsBinding.instance.endOfFrame.then((_) {
+        navigateToWeatherScreen();
+      }),
+    );
   }
 
   Future<void> navigateToWeatherScreen() async {
-    await WidgetsBinding.instance.endOfFrame;
     await Future<void>.delayed(const Duration(milliseconds: 500));
     if (!mounted) {
       return;
@@ -29,6 +32,7 @@ class _GreenScreenState extends State<GreenScreen> {
         },
       ),
     );
+    await navigateToWeatherScreen();
   }
 
   @override

--- a/lib/green_screen.dart
+++ b/lib/green_screen.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_training/weather_info_screen.dart';
+
+class GreenScreen extends StatefulWidget {
+  const GreenScreen({super.key});
+
+  @override
+  State<GreenScreen> createState() => _GreenScreenState();
+}
+
+class _GreenScreenState extends State<GreenScreen> {
+  @override
+  void initState() {
+    super.initState();
+    unawaited(navigateToWeatherScreen());
+  }
+
+  Future<void> navigateToWeatherScreen() async {
+    await WidgetsBinding.instance.endOfFrame;
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    if (!mounted) {
+      return;
+    }
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (context) {
+          return const WeatherInfoScreen();
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.green,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/weather_info_screen.dart';
+import 'package:flutter_training/green_screen.dart';
 
 void main() {
   runApp(const MainApp());
@@ -12,7 +12,7 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       home: Scaffold(
-        body: WeatherInfoScreen(),
+        body: GreenScreen(),
       ),
     );
   }

--- a/lib/weather_info_screen.dart
+++ b/lib/weather_info_screen.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_training/green_screen.dart';
 import 'package:flutter_training/utils/extensions/enum.dart';
 import 'package:flutter_training/weather_condition_panel.dart';
 import 'package:flutter_training/weather_kind.dart';
@@ -36,7 +38,17 @@ class _WeatherInfoScreenState extends State<WeatherInfoScreen> {
                     children: [
                       Expanded(
                         child: TextButton(
-                          onPressed: () {},
+                          onPressed: () {
+                            unawaited(
+                              Navigator.of(context).push(
+                                MaterialPageRoute<void>(
+                                  builder: (context) {
+                                    return const GreenScreen();
+                                  },
+                                ),
+                              ),
+                            );
+                          },
                           child: Text(
                             'Close',
                             textAlign: TextAlign.center,

--- a/lib/weather_info_screen.dart
+++ b/lib/weather_info_screen.dart
@@ -20,66 +20,68 @@ class _WeatherInfoScreenState extends State<WeatherInfoScreen> {
   @override
   Widget build(BuildContext context) {
     final labelLargeStyle = Theme.of(context).textTheme.labelLarge;
-    return Center(
-      child: FractionallySizedBox(
-        widthFactor: 0.5,
-        child: Column(
-          children: [
-            const Spacer(),
-            WeatherConditionPanel(
-              weatherKind: _weatherKind,
-              labelLargeStyle: labelLargeStyle,
-            ),
-            Expanded(
-              child: Column(
-                children: [
-                  const SizedBox(height: 80),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: TextButton(
-                          onPressed: () {
-                            unawaited(
-                              Navigator.of(context).push(
-                                MaterialPageRoute<void>(
-                                  builder: (context) {
-                                    return const GreenScreen();
-                                  },
-                                ),
-                              ),
-                            );
-                          },
-                          child: Text(
-                            'Close',
-                            textAlign: TextAlign.center,
-                            style:
-                                labelLargeStyle?.copyWith(color: Colors.blue),
-                          ),
-                        ),
-                      ),
-                      Expanded(
-                        child: TextButton(
-                          onPressed: () {
-                            final name = _yumemiWeather.fetchSimpleWeather();
-                            setState(() {
-                              _weatherKind =
-                                  WeatherKind.values.byNameOrNull(name);
-                            });
-                          },
-                          child: Text(
-                            'Reload',
-                            textAlign: TextAlign.center,
-                            style:
-                                labelLargeStyle?.copyWith(color: Colors.blue),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
+    return Scaffold(
+      body: Center(
+        child: FractionallySizedBox(
+          widthFactor: 0.5,
+          child: Column(
+            children: [
+              const Spacer(),
+              WeatherConditionPanel(
+                weatherKind: _weatherKind,
+                labelLargeStyle: labelLargeStyle,
               ),
-            ),
-          ],
+              Expanded(
+                child: Column(
+                  children: [
+                    const SizedBox(height: 80),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () {
+                              unawaited(
+                                Navigator.of(context).push(
+                                  MaterialPageRoute<void>(
+                                    builder: (context) {
+                                      return const GreenScreen();
+                                    },
+                                  ),
+                                ),
+                              );
+                            },
+                            child: Text(
+                              'Close',
+                              textAlign: TextAlign.center,
+                              style:
+                                  labelLargeStyle?.copyWith(color: Colors.blue),
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () {
+                              final name = _yumemiWeather.fetchSimpleWeather();
+                              setState(() {
+                                _weatherKind =
+                                    WeatherKind.values.byNameOrNull(name);
+                              });
+                            },
+                            child: Text(
+                              'Reload',
+                              textAlign: TextAlign.center,
+                              style:
+                                  labelLargeStyle?.copyWith(color: Colors.blue),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/weather_info_screen.dart
+++ b/lib/weather_info_screen.dart
@@ -1,6 +1,4 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter_training/green_screen.dart';
 import 'package:flutter_training/utils/extensions/enum.dart';
 import 'package:flutter_training/weather_condition_panel.dart';
 import 'package:flutter_training/weather_kind.dart';
@@ -40,15 +38,7 @@ class _WeatherInfoScreenState extends State<WeatherInfoScreen> {
                         Expanded(
                           child: TextButton(
                             onPressed: () {
-                              unawaited(
-                                Navigator.of(context).push(
-                                  MaterialPageRoute<void>(
-                                    builder: (context) {
-                                      return const GreenScreen();
-                                    },
-                                  ),
-                                ),
-                              );
+                              Navigator.of(context).pop();
                             },
                             child: Text(
                               'Close',


### PR DESCRIPTION
## 課題

close #4

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] [StatefulWidget](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) を継承した Widget で構築された新しい画面を追加する
- [x] 新しい画面の背景色は [Colors.green](https://api.flutter.dev/flutter/material/Colors/green-constant.html) に設定する
- [x] アプリ起動時に新しい画面に遷移する
- [x] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->




| expected | actual |
|----------|--------|
|![image](https://github.com/user-attachments/assets/cc200b87-b4ba-4cb8-9e51-5a6ae9c25ebe)| <video src="https://github.com/user-attachments/assets/decb9192-9fd5-432c-8688-3c1e0408f7c3">|