### PR TITLE
Session5: Error Handling

### DIFF
--- a/lib/weather_info_screen.dart
+++ b/lib/weather_info_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_training/utils/extensions/enum.dart';
 import 'package:flutter_training/weather_condition_panel.dart';
@@ -14,6 +16,27 @@ class WeatherInfoScreen extends StatefulWidget {
 class _WeatherInfoScreenState extends State<WeatherInfoScreen> {
   final YumemiWeather _yumemiWeather = YumemiWeather();
   WeatherKind? _weatherKind;
+
+  Future<void> _showErrorDialog(String message) async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Error occurred'),
+          content: Text(message),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('OK'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -51,11 +74,16 @@ class _WeatherInfoScreenState extends State<WeatherInfoScreen> {
                         Expanded(
                           child: TextButton(
                             onPressed: () {
-                              final name = _yumemiWeather.fetchSimpleWeather();
-                              setState(() {
-                                _weatherKind =
-                                    WeatherKind.values.byNameOrNull(name);
-                              });
+                              try {
+                                final name =
+                                    _yumemiWeather.fetchThrowsWeather('tokyo');
+                                setState(() {
+                                  _weatherKind =
+                                      WeatherKind.values.byNameOrNull(name);
+                                });
+                              } on YumemiWeatherError catch (e) {
+                                unawaited(_showErrorDialog(e.toString()));
+                              }
                             },
                             child: Text(
                               'Reload',


### PR DESCRIPTION
## 課題

close #6 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) でメッセージを表示する
メッセージの内容は自由
- [x] [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) の OK ボタンをタップすると、ダイアログを閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
|![image](https://github.com/user-attachments/assets/4aa4fb1d-4f2e-4fbf-94f3-a4d84d867255)| <video src="https://github.com/user-attachments/assets/40db97df-d075-4f46-a765-1bd0fbea7ca8"> |